### PR TITLE
Add CLI test for custom greeting

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import sys
+
+from sora_imagegen_tool import cli
+
+
+def test_cli_prints_custom_greeting(capsys, monkeypatch):
+    """CLI should print a personalized greeting when --name is supplied."""
+    name = "Atlas"
+    monkeypatch.setattr(sys, "argv", ["sora_imagegen_tool", "--name", name])
+    cli.main()
+    captured = capsys.readouterr()
+    assert captured.out.strip() == f"Hello, {name}!"


### PR DESCRIPTION
## Summary
- test CLI prints personalized greeting when --name argument is provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f63e5dcd08327bfbdd74f80e2b5b2