### PR TITLE
Guard scene filtering against missing index

### DIFF
--- a/story_to_video.py
+++ b/story_to_video.py
@@ -298,7 +298,11 @@ def main() -> None:
     frames_dir.mkdir(parents=True, exist_ok=True)
 
     scenes = load_prompts(args.prompts_file)
-    scenes = [s for s in scenes if s.get("index") <= args.max_images][: args.max_images]
+    # Guard against missing index before comparing to max_images
+    scenes = [
+        s for s in scenes
+        if s.get("index") is not None and s["index"] <= args.max_images
+    ][: args.max_images]
 
     frame_paths: list[Path] = []
 


### PR DESCRIPTION
## Summary
- Guard scene filtering against missing index before applying max limit

## Testing
- `make preflight`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f63c4ca988327ab62bb52083eb788