### PR TITLE
Normalize preflight wording in story_to_video

### DIFF
--- a/story_to_video.py
+++ b/story_to_video.py
@@ -167,13 +167,13 @@ def run_preflight(script_dir: Path) -> None:
     """Run preflight.py (black/flake8/mypy/pytest). Abort if it fails."""
     preflight = script_dir / "preflight.py"
     if not preflight.exists():
-        logging.warning("preflight.py not found. Skipping pre-flight checks.")
+        logging.warning("preflight.py not found. Skipping preflight checks.")
         return
-    logging.info("Running pre-flight checks (black, flake8, mypy, pytest)…")
+    logging.info("Running preflight checks (black, flake8, mypy, pytest)…")
     cmd = f'"{sys.executable}" "{preflight}"'
     result = subprocess.run(cmd, shell=True)
     if result.returncode != 0:
-        raise SystemExit("Pre-flight checks failed. Fix issues and re-run.")
+        raise SystemExit("Preflight checks failed. Fix issues and re-run.")
 
 
 # -------------------------------------


### PR DESCRIPTION
## Summary
- replace `pre-flight` with `preflight` in preflight runner logs

## Testing
- `uv run ruff check story_to_video.py` *(fails: import sorting, unnecessary mode args, B904 in except blocks)*
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f63b129148327a65500f0d847cbb0