### PR TITLE
Fix log directory creation in setup_logging

### DIFF
--- a/story_to_video.py
+++ b/story_to_video.py
@@ -119,7 +119,10 @@ def setup_logging(quiet: bool) -> None:
     console_handler.setLevel(console_level)
     console_handler.setFormatter(logging.Formatter("%(message)s"))
     root_logger.addHandler(console_handler)
-    file_handler = logging.FileHandler("../story-to-video/run.log", mode="a", encoding="utf-8")
+    log_dir = Path(__file__).resolve().parent / "story-to-video"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "run.log"
+    file_handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
     root_logger.addHandler(file_handler)

--- a/tests/test_setup_logging.py
+++ b/tests/test_setup_logging.py
@@ -1,0 +1,52 @@
+import importlib.util
+import importlib.machinery
+import sys
+import types
+from pathlib import Path
+
+
+def test_setup_logging_creates_logfile(tmp_path, monkeypatch):
+    class Dummy:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    # stub openai
+    sys.modules['openai'] = types.SimpleNamespace(OpenAI=Dummy)
+
+    # stub moviepy structures
+    moviepy = types.ModuleType('moviepy')
+    video = types.ModuleType('moviepy.video')
+    video_io = types.ModuleType('moviepy.video.io')
+    image_module = types.ModuleType('moviepy.video.io.ImageSequenceClip')
+    image_module.ImageSequenceClip = Dummy
+    video_io.ImageSequenceClip = image_module
+    audio = types.ModuleType('moviepy.audio')
+    audio_io = types.ModuleType('moviepy.audio.io')
+    audio_module = types.ModuleType('moviepy.audio.io.AudioFileClip')
+    audio_module.AudioFileClip = Dummy
+    audio_io.AudioFileClip = audio_module
+    moviepy.video = video
+    moviepy.audio = audio
+    sys.modules['moviepy'] = moviepy
+    sys.modules['moviepy.video'] = video
+    sys.modules['moviepy.video.io'] = video_io
+    sys.modules['moviepy.video.io.ImageSequenceClip'] = image_module
+    sys.modules['moviepy.audio'] = audio
+    sys.modules['moviepy.audio.io'] = audio_io
+    sys.modules['moviepy.audio.io.AudioFileClip'] = audio_module
+
+    sys.modules['tqdm'] = types.SimpleNamespace(tqdm=lambda *a, **kw: None)
+
+    loader = importlib.machinery.SourceFileLoader(
+        'story_to_video', str(Path(__file__).resolve().parents[1] / 'story_to_video.py')
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+
+    module.__file__ = str(tmp_path / 'story_to_video.py')
+    monkeypatch.chdir(tmp_path)
+
+    module.setup_logging(False)
+
+    assert (tmp_path / 'story-to-video' / 'run.log').exists()


### PR DESCRIPTION
## Summary
- create log directory relative to `story_to_video.py` before configuring file handler
- add regression test for logging setup using stubbed dependencies

## Testing
- `python scripts/preflight.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5ba4f32c832796ef4a06552c25c5